### PR TITLE
Fix async method lacks await warning

### DIFF
--- a/App.razor
+++ b/App.razor
@@ -48,7 +48,7 @@
     private List<Action> actionsToRunAfterRender = new List<Action>();
     private bool isExpression6PartFormat = true;
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
         var uri = new Uri(NavigationManager.Uri);
         var queryPairs = QueryHelpers.ParseQuery(uri.Query);
@@ -58,6 +58,8 @@
         }
 
         SetExpression();
+
+        return Task.CompletedTask;
     }
 
     protected override Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
This PR fixes the following [warning during building](https://github.com/Swimburger/NCrontabTester/runs/969228760#step:4:81):

```
App.razor(51,35): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. [/bin/staticsites/ss-oryx/app-int/NCrontabTester.csproj]
```
