### PR TITLE
Move warning/error outside occurences list

### DIFF
--- a/App.razor
+++ b/App.razor
@@ -18,19 +18,20 @@
     </div>
 </div>
 <label>Occurrences Output:</label>
+@if (!string.IsNullOrEmpty(errorMessage))
+{
+    <div class="alert alert-danger" role="alert">
+        @errorMessage
+    </div>
+}
+@if (!isExpression6PartFormat)
+{
+    <div class="alert alert-warning" role="alert">
+        You are using the classic five-part CRON format. Services such as
+        Azure Functions and Azure WebJobs require the six-part format.
+    </div>
+}
 <ul class="occurrences-list">
-    @if (!string.IsNullOrEmpty(errorMessage))
-    {
-        <li style="color: #e74856;">@errorMessage</li>
-    }
-
-    @if (!isExpression6PartFormat)
-    {
-        <li style="color: #f9f1a5;">
-            You are using the classic five-part CRON format. Services such as
-            Azure Functions and Azure WebJobs require the six-part format.
-        </li>
-    }
     @foreach (var occurence in occurrences)
     {
         <li>


### PR DESCRIPTION
This PR changes the warning/error that appears as part of the `<ul>` of occurrences to their own `<div>` elements that outside and above the list…

### Error

![localhost_5000_](https://user-images.githubusercontent.com/20511/90333463-38f01c00-dfc6-11ea-8ce0-c4c05159a1d5.png)

### Warning

![localhost_5000_](https://user-images.githubusercontent.com/20511/90333483-61781600-dfc6-11ea-8459-20b1572f39ab.png)
